### PR TITLE
Drop Ruby 2.4/2.5/2.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
-          - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
             coverage: "yes"


### PR DESCRIPTION
The versions are EoL. And we need to switch to a newer rbvmoni version, which also requires newer rubies.
