### PR TITLE
Replace dead dependency rbvmomi with rbvmomi2

### DIFF
--- a/beaker-vcloud.gemspec
+++ b/beaker-vcloud.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'rbvmomi', '~> 1.9'
+  s.add_runtime_dependency 'rbvmomi2', '~> 3.7', '>= 3.7.1'
   s.add_runtime_dependency 'beaker-vmware'
   s.add_runtime_dependency 'beaker', '>= 4', '< 6'
 end


### PR DESCRIPTION
rbvmomi Was developed by vmware itself, but they stopped it. rbvmomi2 is the community successor. See also
5f612f82179509c5245c0c71affc80fed29ae47d at beaker-vmware where we did the same.